### PR TITLE
Replace `make` by `ninja`

### DIFF
--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -29,4 +29,4 @@ else
     cd build
 fi
 
-ccache make -j$NPROC
+ninja -j$NPROC


### PR DESCRIPTION
The Ceph project replaced `make` by `ninja`:

* https://github.com/ceph/ceph/pull/40408
* https://github.com/ceph/ceph/pull/39826

Signed-off-by: Tatjana Dehler <tdehler@suse.com>