### PR TITLE
Check if `ninja` is installed

### DIFF
--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -29,4 +29,8 @@ else
     cd build
 fi
 
-ninja -j$NPROC
+if which ninja; then
+    ninja -j$NPROC
+else
+    ccache make -j$NPROC
+fi


### PR DESCRIPTION
Check if `ninja` is installed before using it in case of older Ceph releases `pacific`, `octopus`, ...

If it's not installed fall back to `make`.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>