### PR TITLE
To be able to build Ceph 'master' from scratch, our build scripts need some adaptations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN zypper -n install \
         python3-Routes \
         python3-scipy \
         python3-Werkzeug \
+        python3-natsort \
+        python3-asyncssh \
         xvfb-run
 
 # temporary fix for error regarding version of tempora

--- a/shared/bin/setup-ceph.sh
+++ b/shared/bin/setup-ceph.sh
@@ -11,6 +11,9 @@ ARGS="-DWITH_PYTHON3=3 -DWITH_RADOSGW_AMQP_ENDPOINT=OFF -DWITH_RADOSGW_KAFKA_END
 
 NPROC=${NPROC:-$(nproc --ignore=2)}
 
+# Other dependencies
+zypper -n install utf8proc-devel
+
 # SSO dependencies
 zypper -n install libxmlsec1-1 libxmlsec1-nss1 libxmlsec1-openssl1 xmlsec1-devel xmlsec1-openssl-devel
 pip install python3-saml


### PR DESCRIPTION
- Add 'python3-asyncssh' for cephadm module
- Add 'python3-natsort' for dashboard module

Signed-off-by: Volker Theile <vtheile@suse.com>